### PR TITLE
improvements to documentation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,5 +9,5 @@ PhyloNetworks = "33ad39ac-ed31-50eb-9b15-43d0656eaa72"
 
 [compat]
 Distributions = "0.25"
-PhyloNetworks = "0.11, 0.12, 0.13, 0.14, 0.15"
+PhyloNetworks = "0.15.1"
 julia = "1.5"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -10,3 +10,4 @@ RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
 
 [compat]
 Documenter = "~0.27"
+PhyloPlots = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -25,4 +25,5 @@ makedocs(;
 deploydocs(;
     repo="github.com/cecileane/PhyloCoalSimulations.jl",
     devbranch="main",
+    push_preview = true,
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,7 +17,9 @@ makedocs(;
         "home" => "index.md",
         "manual" => [
             "getting started" => "man/getting_started.md",
-            "more examples" => "man/mapping_genetree_to_network.md",
+            "mapping gene trees into the species network" => "man/mapping_genetree_to_network.md",
+            "converting between units" => "man/converting_coal2generation_units.md",
+            "more examples" => "man/more_examples.md",
         ],
     ],
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,7 +7,6 @@ CurrentModule = PhyloCoalSimulations
 [PhyloCoalSimulations](https://github.com/cecileane/PhyloCoalSimulations.jl)
 is a [Julia](http://julialang.org) package to
 simulate phylogenies under the coalescent.
-
 It depends on [PhyloNetworks](https://github.com/crsl4/PhyloNetworks.jl)
 for the phylogenetic data structures, and manipulation of phylogenies.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,6 +16,8 @@ For a tutorial, see the manual:
 Pages = [
     "man/getting_started.md",
     "man/mapping_genetree_to_network.md",
+    "man/converting_coal2generation_units.md",
+    "man/more_examples.md",
 ]
 Depth = 3
 ```

--- a/docs/src/man/converting_coal2generation_units.md
+++ b/docs/src/man/converting_coal2generation_units.md
@@ -1,12 +1,13 @@
 ```@setup converting
 using PhyloNetworks, PhyloCoalSimulations
 net = readTopology("((C:0.9,(B:0.2)#H1:0.7::0.6)I1:0.6,(#H1:0.6::0.4,A:1.0)I2:0.5)I3;");
-using Random; Random.seed!(261); # as in mapping block
-tree = simulatecoalescent(net,1,1; nodemapping=true)[1];
 ```
-# converting coalescent units to number of generations
 
-Edge lengths in gene trees are simulated in coalescent units.
+# converting between units
+
+## converting edge lengths in gene trees
+
+In earlier examples, edge lengths in gene trees are simulated in coalescent units.
 These lengths can be converted into numbers of generations by multiplying by
 the effective population size Nₑ, since coalescent units are `u = g/Nₑ`.
 This can be done with different Nₑ's across different edges in the network,
@@ -20,11 +21,13 @@ including the root edge.
 Here is an example using the same network and simulated gene tree as earlier.
 ```@repl converting
 writeTopology(net)
+using Random; Random.seed!(261); # as in mapping block
+tree = simulatecoalescent(net,1,1; nodemapping=true)[1];
 writeTopology(tree, round=true)
 ```
 ![example 1, same as in mapping section](../assets/figures/genetree_example1.svg)
 
-Let's set Nₑ set to 1,000 in all populations (including the population above the root),
+Let's set Nₑ to 1,000 in all populations, including the population above the root,
 except in edge 6. For this edge 6 (population leading to species A),
 let's set its Nₑ to 10,000.
 
@@ -50,7 +53,7 @@ Using the approximation, the simulated number of generations will typically be
 between 0-3 generations. But this is an extreme case, and the approximation
 should be very good even for moderate Nₑ's.
 
-# starting with # of generations in the network
+# number of generations in the network and gene trees
 
 If our input network has edge lengths in number of generations,
 then we need extra information to simulate under the coalescent:
@@ -79,13 +82,19 @@ push!(Ne, rootedgenumber => Ne_distribution()); # Nₑ above the root
 Ne
 ```
 
-To simulate gene trees with edge lengths in generations,
-we can use a convenience wrapper function that
-- creates the species phylogeny with edge lengths in coalescent units,
-- simulates gene trees with lengths in coalescent units, then
-- converts gene trees to have lengths in number of generations:
+To simulate gene trees with edge lengths in generations, we can use a
+convenience wrapper function that takes **Nₑ as an extra input** to:
+- convert edge lengths to coalescent units in the species phylogeny,
+- simulate gene trees with lengths in coalescent units, then
+- convert gene trees to have lengths in number of generations:
 
 ```@repl converting
-genetree = simulatecoalescent(net_coal,3,1, Ne; nodemapping=true);
-writeMultiTopology(genetree, stdout) # 3 gene trees, lengths in #generations
+genetree_gen = simulatecoalescent(net_gen,3,1, Ne; nodemapping=true);
+writeMultiTopology(genetree_gen, stdout) # 3 gene trees, lengths in #generations
 ```
+
+!!! warning
+    When Nₑ is given as an extra input to `simulatecoalescent`,
+    edge lengths in the network are assumed to be in # of generations.
+    If Nₑ is *not* given as input, then edge lengths are assumed to be
+    in coalescent units.

--- a/docs/src/man/converting_coal2generation_units.md
+++ b/docs/src/man/converting_coal2generation_units.md
@@ -1,0 +1,51 @@
+```@setup converting
+using PhyloNetworks, PhyloCoalSimulations
+net = readTopology("((C:0.9,(B:0.2)#H1:0.7::0.6)I1:0.6,(#H1:0.6::0.4,A:1.0)I2:0.5)I3;");
+using Random; Random.seed!(261); # as in mapping block
+tree = simulatecoalescent(net,1,1; nodemapping=true)[1];
+```
+# converting coalescent units to number of generations
+
+Edge lengths in gene trees are simulated in coalescent units.
+These lengths can be converted into numbers of generations by multiplying by
+the effective population size Nₑ, since coalescent units are `u = g/Nₑ`.
+This can be done with different Nₑ's across different edges in the network,
+including the root edge.
+
+!!! info "diploid versus haploid Nₑ"
+    The formula `u = g/Nₑ` uses the haploid effective population size Nₑ.
+    For diploid taxa and autosomes, the haploid population size should be twice
+    the diploid population size, for example.
+
+Here is an example using the same network and simulated gene tree as earlier.
+```@repl converting
+writeTopology(net)
+writeTopology(tree, round=true)
+```
+![example 1, same as in mapping section](../assets/figures/genetree_example1.svg)
+
+Let's set Nₑ set to 1,000 in all populations (including the population above the root),
+except in edge 6. For this edge 6 (population leading to species A),
+let's set its Nₑ to 10,000.
+
+```@repl converting
+Ne = Dict(e.number => 1_000 for e in net.edge);
+push!(Ne, 8 => 1_000); # add Ne for the edge above the network's root
+Ne[6] = 10_000;        # higher population size for the edge to species A
+Ne
+writeTopology(tree, round=true) # lengths in coalescent units: before unit conversion
+# convert edge lengths in gene tree from coalescent units to # generations
+for e in tree.edge
+  e.length = round(e.length * Ne[e.inCycle]) # round: to get integers
+end
+writeTopology(tree, round=true) # lengths in # of generations
+```
+
+Note that the simulation model assumes an infinite-Nₑ approximation,
+so the rescaling of edge lengths from coalescent units to number of generations
+will be imperfect for very small populations size. With the extreme Nₑ=1,
+coalescences should be immediate in a single generation back in time: g=1.
+Using the approximation, the simulated number of generations will typically be
+between 0-3 generations. But this is an extreme case, and the approximation
+should be very good even for moderate Nₑ's.
+

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -1,7 +1,7 @@
 ```@setup getting_started
 using PhyloNetworks, PhyloCoalSimulations, RCall
-mkpath("../assets/figures")
-figname(x) = joinpath("..", "assets", "figures", x)
+figpath = joinpath("..", "assets", "figures"); mkpath(figpath)
+figname(x) = joinpath(figpath, x)
 using Random; Random.seed!(432)
 ```
 
@@ -42,9 +42,9 @@ net = readTopology("((C:0.9,(B:0.2)#H1:0.7::0.6):0.6,(#H1:0.6,A:1):0.5);");
 using PhyloPlots
 R"svg"(figname("net3taxa.svg"), width=6, height=3); # hide
 R"par"(mar=[.1,.1,.1,.1]); R"layout"([1 2]); # hide
-plot(net, :R, showEdgeNumber=true, showIntNodeLabel=true, showGamma=true, tipOffset=0.1);
-R"mtext"("in black: edge numbers", side=1, line=-1);  # hide
-plot(net, :R, showEdgeLength=true, useEdgeLength=true, tipOffset=0.1);
+plot(net, showedgenumber=true, shownodelabel=true, showgamma=true, tipoffset=0.1);
+R"mtext"("in grey: edge numbers", side=1, line=-1);  # hide
+plot(net, showedgelength=true, useedgelength=true, tipoffset=0.1);
 R"mtext"("in black: edge lengths", side=1, line=-1);  # hide
 R"dev.off()" # hide
 nothing # hide
@@ -96,9 +96,9 @@ R"par"(mar=[.1,.1,.1,.1]); R"layout"([1 2]); # hide
 using DataFrames
 for i in 1:2
   gt = trees[i]
-  plot(gt, :R, tipOffset=0.1,
-               edgeLabel=DataFrame(number = [e.number  for e in gt.edge],
-                                   label  = [e.inCycle for e in gt.edge]));
+  plot(gt, tipoffset=0.1,
+           edgelabel=DataFrame(number = [e.number  for e in gt.edge],
+                               label  = [e.inCycle for e in gt.edge]));
   R"mtext"("gene $i", line=-1) # hide
 end
 R"mtext"("numbers: network edge each gene lineage maps to, at time of coalescence.\n8 = number of edge above the network root", side=1, line=-1, outer=true);  # hide

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -63,10 +63,10 @@ same distance from the root), then gene trees will also be ultrametric.
 ### basic example: simulate, save to file, plot
 
 We use [`simulatecoalescent`](@ref) to simulate gene trees along this network.
-Below, we simulate 2 gene trees. By default, there's 1 individual per species.
+Below, we simulate 2 gene trees, with 1 individual per species.
 
 ```@repl getting_started
-trees = simulatecoalescent(net, 2)
+trees = simulatecoalescent(net, 2, 1)
 ```
 
 Branch lengths are assumed to be in coalescent units in the species network

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -55,7 +55,7 @@ Note that this example network is not time consistent: the length of the path
 from the root to the hybridization node H1 is different depending if we go
 through the major edge (0.6+0.7=1.3) or the minor edge (0.5+0.6=1.1).
 
-Coalescent simulations can be performed along on such networks, also
+Coalescent simulations can be performed along such networks, also
 along non-ultrametric networks.
 If the network is ultrametric (time-consistent, and with all tips at the
 same distance from the root), then gene trees will also be ultrametric.
@@ -96,8 +96,9 @@ R"par"(mar=[.1,.1,.1,.1]); R"layout"([1 2]); # hide
 using DataFrames
 for i in 1:2
   gt = trees[i]
-  plot(gt, :R, tipOffset=0.1, edgeLabel=DataFrame(number=[e.number for e in gt.edge],
-                                                  label=[e.inCycle for e in gt.edge]));
+  plot(gt, :R, tipOffset=0.1, useEdgeLength=true,
+               edgeLabel=DataFrame(number = [e.number  for e in gt.edge],
+                                   label  = [e.inCycle for e in gt.edge]));
   R"mtext"("gene $i", line=-1) # hide
 end
 R"mtext"("numbers: network edge each gene lineage maps to, at time of coalescence.\n8 = number of edge above the network root", side=1, line=-1, outer=true);  # hide

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -96,7 +96,7 @@ R"par"(mar=[.1,.1,.1,.1]); R"layout"([1 2]); # hide
 using DataFrames
 for i in 1:2
   gt = trees[i]
-  plot(gt, :R, tipOffset=0.1, useEdgeLength=true,
+  plot(gt, :R, tipOffset=0.1,
                edgeLabel=DataFrame(number = [e.number  for e in gt.edge],
                                    label  = [e.inCycle for e in gt.edge]));
   R"mtext"("gene $i", line=-1) # hide

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -56,7 +56,7 @@ from the root to the hybridization node H1 is different depending if we go
 through the major edge (0.6+0.7=1.3) or the minor edge (0.5+0.6=1.1).
 
 Coalescent simulations can be performed along on such networks, also
-along non-ultrametric network.
+along non-ultrametric networks.
 If the network is ultrametric (time-consistent, and with all tips at the
 same distance from the root), then gene trees will also be ultrametric.
 

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -51,6 +51,15 @@ nothing # hide
 ```
 ![3-taxon network](../assets/figures/net3taxa.svg)
 
+Note that this example network is not time consistent: the length of the path
+from the root to the hybridization node H1 is different depending if we go
+through the major edge (0.6+0.7=1.3) or the minor edge (0.5+0.6=1.1).
+
+Coalescent simulations can be performed along on such networks, also
+along non-ultrametric network.
+If the network is ultrametric (time-consistent, and with all tips at the
+same distance from the root), then gene trees will also be ultrametric.
+
 ### basic example: simulate, save to file, plot
 
 We use [`simulatecoalescent`](@ref) to simulate gene trees along this network.
@@ -59,6 +68,10 @@ Below, we simulate 2 gene trees. By default, there's 1 individual per species.
 ```@repl getting_started
 trees = simulatecoalescent(net, 2)
 ```
+
+Branch lengths are assumed to be in coalescent units in the species network
+(number of generations / effective population size), and edge lengths in gene
+trees are also in coalescent units.
 
 We can work with these gene trees within Julia with downstream code,
 and/or we can save them to a file:

--- a/docs/src/man/mapping_genetree_to_network.md
+++ b/docs/src/man/mapping_genetree_to_network.md
@@ -74,14 +74,25 @@ network like this:
   before coalescing with the ancestor of the other lineages (which have already
   coalesced by then).
 
+## cleaning gene trees
+
 Almost all examples below use this mapping information via the extra degree-2
 nodes and the extra edges between these nodes.
 
 But we may want to "clean" gene trees of their degree-2 nodes at some point.
 This can be done with the `PhyloNetworks` utility `removedegree2nodes!`, like this:
-`PhyloNetworks.removedegree2nodes!(tree, true)`. The option `true` is to keep
-the root, even if it's of degree 2.
-[PhyloNetworks v0.15.0 does not have this option and removes the root of degree 2, but the option will be available in the next version of PhyloNetworks. This is not a problem for simulating sequences along gene trees when using a reversible substitution model, for which the root placement doesn't matter.]
+
+```julia
+PhyloNetworks.removedegree2nodes!(tree, true)
+```
+The option `true` is to keep the root, even if it's of degree 2.
+
+!!! note
+    PhyloNetworks v0.15.0 does not have this option and
+    removes the root of degree 2, but the option will be available in the next
+    version of PhyloNetworks.
+    This is not a problem for simulating sequences along gene trees when using a
+    reversible substitution model, for which the root placement doesn't matter.
 
 # converting coalescent units to number of generations
 

--- a/docs/src/man/mapping_genetree_to_network.md
+++ b/docs/src/man/mapping_genetree_to_network.md
@@ -1,6 +1,7 @@
 ```@setup mapping
 using PhyloNetworks, PhyloPlots, PhyloCoalSimulations, RCall, DataFrames
-figname(x) = joinpath("..", "assets", "figures", x)
+figpath = joinpath("..", "assets", "figures"); mkpath(figpath)
+figname(x) = joinpath(figpath, x)
 ```
 # mapping gene trees into the species phylogeny
 
@@ -50,12 +51,12 @@ The network is shown on the left below, with edges annotated by their numbers.
 ```@example mapping
 R"svg"(figname("genetree_example1.svg"), width=7.5, height=3); # hide
 R"par"(mar=[.1,.2,.1,.2], oma=[0,0,0,0.8]); R"layout"([1 2]); # hide
-plot(net, :R, showEdgeNumber=true, showIntNodeLabel=true, tipOffset=0.1);
+plot(net, showedgenumber=true, shownodelabel=true, tipoffset=0.1);
 R"mtext"("species network", side=3, line=-1);  # hide
 R"mtext"("grey: population edge number", side=1, line=-1, cex=0.9);  # hide
-plot(tree, :R, edgeLabel=DataFrame(number=[e.number for e in tree.edge],
-                                   label=[e.inCycle for e in tree.edge]),
-               showIntNodeLabel=true, tipOffset=0.1);
+plot(tree, edgelabel=DataFrame(number=[e.number for e in tree.edge],
+                               label=[e.inCycle for e in tree.edge]),
+           edgelabelcolor="red4", shownodelabel=true, tipoffset=0.1);
 R"mtext"("gene tree", side=3, line=-1);  # hide
 R"mtext"("red (edge inCycle value): population a gene edge maps into", side=1, line=-2, cex=0.9); # hide
 R"mtext"("black (node names): speciation/reticulation a node maps to", side=1, line=-1, cex=0.9); # hide

--- a/docs/src/man/mapping_genetree_to_network.md
+++ b/docs/src/man/mapping_genetree_to_network.md
@@ -48,18 +48,21 @@ the gene tree into the species network.
 The network is shown on the left below, with edges annotated by their numbers.
 
 ```@example mapping
-R"svg"(figname("genetrees_moreexample1.svg"), width=6, height=3); # hide
-R"par"(mar=[.1,.1,.1,.1]); R"layout"([1 2]); # hide
+R"svg"(figname("genetree_example1.svg"), width=7.5, height=3); # hide
+R"par"(mar=[.1,.2,.1,.2], oma=[0,0,0,0.8]); R"layout"([1 2]); # hide
 plot(net, :R, showEdgeNumber=true, showIntNodeLabel=true, tipOffset=0.1);
 R"mtext"("species network", side=3, line=-1);  # hide
+R"mtext"("grey: population edge number", side=1, line=-1, cex=0.9);  # hide
 plot(tree, :R, edgeLabel=DataFrame(number=[e.number for e in tree.edge],
                                    label=[e.inCycle for e in tree.edge]),
                showIntNodeLabel=true, tipOffset=0.1);
 R"mtext"("gene tree", side=3, line=-1);  # hide
+R"mtext"("red (edge inCycle value): population a gene edge maps into", side=1, line=-2, cex=0.9); # hide
+R"mtext"("black (node names): speciation/reticulation a node maps to", side=1, line=-1, cex=0.9); # hide
 R"dev.off()" # hide
 nothing # hide
 ```
-![example 1: degree-2 node names in gene tree](../assets/figures/genetrees_moreexample1.svg)
+![example 1: degree-2 node names in gene tree](../assets/figures/genetree_example1.svg)
 
 In the gene tree (right), each lineage is annotated by the network
 edge it maps into. Degree-2 nodes appear via their names, such that each
@@ -88,148 +91,13 @@ PhyloNetworks.removedegree2nodes!(tree, true)
 The option `true` is to keep the root, even if it's of degree 2.
 
 !!! note
-    PhyloNetworks v0.15.0 does not have this option and
-    removes the root of degree 2, but the option will be available in the next
-    version of PhyloNetworks.
+    This option is available in the development version of PhyloNetworks
+    (and will be available in the next registered version).
+    Using PhyloNetworks v0.15.0, which does not have this option, do this instead:
+    ```julia
+    PhyloNetworks.removedegree2nodes!(tree)
+    ```
+    It will remove *all* degree-2 nodes, including the root.
     This is not a problem for simulating sequences along gene trees when using a
     reversible substitution model, for which the root placement doesn't matter.
 
-# converting coalescent units to number of generations
-
-Edge lengths in gene trees are simulated in coalescent units.
-These lengths can be converted into numbers of generations by multiplying by
-the effective population size Nₑ, since coalescent units are `u = g/Nₑ`.
-This can be done with different Nₑ's across different edges in the network,
-including the root edge. Here is an example, with Nₑ set to 1,000 in all
-populations (including the population above the root),
-except in edge 6: the population leading to species A has its Nₑ set to 10,000.
-
-```@repl mapping
-Ne = Dict(e.number => 1_000 for e in net.edge);
-push!(Ne, 8 => 1_000); # add Ne for the edge above the network's root
-Ne[6] = 10_000;        # higher population size for the edge to species A
-Ne
-# convert edge lengths in gene tree from coalescent units to # generations
-tree_in_generations = deepcopy(tree)
-for e in tree_in_generations.edge
-  e.length = round(e.length * Ne[e.inCycle]) # round: to get integers
-end
-writeTopology(tree_in_generations, round=true, digits=4) # after rate variation
-```
-
-Note that the simulation model assumes an infinite-Nₑ approximation,
-so the rescaling of edge lengths from coalescent units to number of generations
-will be imperfect for very small populations size. With the extreme Nₑ=1,
-coalescences should be immediate in a single generation back in time: g=1.
-Using the approximation, the simulated number of generations will typically be
-between 0-3 generations. But this is an extreme case, and the approximation
-should be very good even for moderate Nₑ's.
-
-# example uses
-
-##  counting deep coalescences
-
-The number of deep coalescences can be quantified as the number of
-"extra" lineages due to incomplete lineage sorting, that can be calculated
-from embedding the gene tree into the species phylogeny
-(see [Maddison 1997](https://doi.org/10.1093/sysbio/46.3.523) for species trees).
-For a speciation node in the species tree (e.g. I1), there are extra lineages
-in the gene tree, owing to a lack of coalescence, if there are more than 2 gene
-lineages mapping to this speciation node.
-For each hybridization node (e.g. H1), there are extra lineages if there are
-more than 1 gene lineage mapping to this hybridization node
-(because there's only 1 child edge descending from a hybridization node).
-
-We can count the number of extra lineages by counting the number of degree-2
-nodes in the gene tree mapping to each node in the species network, then
-counting how many are "extra".
-In our gene tree above, we can do it this way:
-
-```@repl mapping
-node_count = Dict(n.name => 0      for n in net.node if !n.leaf) # ignore leaves
-node_hyb = Dict(n.name => n.hybrid for n in net.node if !n.leaf) # true/1 for hybrid nodes
-# traverse the gene tree, to count number of lineages entering each network node
-for n in tree.node
-  (n.leaf || n.name == "") && continue # skip leaves and nodes without a name
-  node_count[n.name] += 1  # increment by 1 the number of lineages entering this node
-end
-node_count # the 2 lineages entering I2 didn't coalesce until they reached I3
-for node in keys(node_count) # modify our counts, to only keep the extras
-  node_count[node] = max(0, node_count[node] - ( node_hyb[node] ? 1 : 2))
-end
-node_count # number of extra lineages: 1 extra entering I3
-deepcoalescence = sum(values(node_count))
-```
-On the particular gene tree we simulated, we counted 1 deep coalescence.
-
-## number of lineages inherited via gene flow
-
-Our network has inheritance γ=0.4 on the minor edge, which we'll call the
-"gene flow" edge, and γ=0.6 on the major hybrid edge, parent to H1 on the major tree.
-But we may be interested in the realized proportion of lineages inherited
-from each parent at H1, realized in the gene trees we actually simulated.
-To do so, we can count the number of gene lineages that are mapped to each
-hybrid edge in the network.
-
-This mapping is stored in the edge attribute `.inCycle`.
-From the plot above, the minor "gene flow" edge is edge number 5 and the
-major hybrid edge has number 3.
-So we can count the gene lineages inherited via gene flow
-as the number of gene tree edges with `inCycle` equal to 5.
-
-If the gene trees have been saved to a file and later read from this file,
-then the `.inCycle` attributes are no longer stored in memory. In this case,
-we can retrieve the mapping information by the internal node names.
-The edges going through gene flow are those whose child node is named "H1"
-and parent node is named "I2".
-
-We use the first option with the `.inCycle` attribute below.
-We get that our one simulated gene tree was indeed inherited via gene flow:
-
-```@repl mapping
-sum(e.inCycle == 5 for e in tree.edge)
-```
-
-To make this more interesting, we can simulate 100 gene trees
-then count how many were inherited via gene flow. If we ask for 2 individuals
-in species B, then each gene may have 2 lineages that enter the hybrid node H1,
-if the two B individuals fail to coalesce. In that case, it's possible that one
-individual lineage was inherited via gene flow, and the other not.
-We'll calculate the gene flow proportion among all these lineages.
-This proportion should be close (but not exactly equal) to the theoretical
-γ=0.4 from the network model.
-
-```@repl mapping
-ngenes = 100
-genetrees = simulatecoalescent(net, ngenes, Dict("B"=>2, "A"=>1, "C"=>1); nodemapping=true);
-length(genetrees)
-nlineages_geneflow = sum(sum(e.inCycle == 5 for e in gt.edge) for gt in genetrees)
-nlineages_major    = sum(sum(e.inCycle == 3 for e in gt.edge) for gt in genetrees)
-proportion_geneflow = nlineages_geneflow / (nlineages_geneflow + nlineages_major)
-```
-
-## rate variation across species
-
-The gene trees resulting from `simulatecoalescent` have their edge lengths
-in coalescent units. One may want to convert them to substitutions per site,
-so as to simulate molecular sequences along these gene trees.
-The mapping information is important to allow for different rates of molecular
-evolution across different species. Here is an example to do this.
-
-We will use the `Distributions` package to simulate rates from a log-normal
-distribution across species, that is, across edges in the species network.
-
-```@repl mapping
-using Distributions
-lognormal_rate_dist = LogNormal(-0.125, 0.5) # μ = -σ²/2 to get a mean of 1.
-networkedge_rate = Dict(e.number => rand(lognormal_rate_dist) for e in net.edge)
-# add entry for the edge above the network's root. Find its number first.
-rootedgenumber = maximum(e.number for e in net.edge) + 1
-push!(networkedge_rate, rootedgenumber => rand(lognormal_rate_dist))
-writeTopology(tree, round=true, digits=4) # before rate variation
-# multiply the length of each gene lineage by the rate of the species edge it maps into
-for e in tree.edge
-  e.length *= networkedge_rate[e.inCycle]
-end
-writeTopology(tree, round=true, digits=4) # after rate variation
-```

--- a/docs/src/man/mapping_genetree_to_network.md
+++ b/docs/src/man/mapping_genetree_to_network.md
@@ -74,7 +74,16 @@ network like this:
   before coalescing with the ancestor of the other lineages (which have already
   coalesced by then).
 
-## converting coalescent units to number of generations
+Almost all examples below use this mapping information via the extra degree-2
+nodes and the extra edges between these nodes.
+
+But we may want to "clean" gene trees of their degree-2 nodes at some point.
+This can be done with the `PhyloNetworks` utility `removedegree2nodes!`, like this:
+`PhyloNetworks.removedegree2nodes!(tree, true)`. The option `true` is to keep
+the root, even if it's of degree 2.
+[PhyloNetworks v0.15.0 does not have this option and removes the root of degree 2, but the option will be available in the next version of PhyloNetworks. This is not a problem for simulating sequences along gene trees when using a reversible substitution model, for which the root placement doesn't matter.]
+
+# converting coalescent units to number of generations
 
 Edge lengths in gene trees are simulated in coalescent units.
 These lengths can be converted into numbers of generations by multiplying by

--- a/docs/src/man/mapping_genetree_to_network.md
+++ b/docs/src/man/mapping_genetree_to_network.md
@@ -11,7 +11,7 @@ as detailed in the documentation of function [`simulatecoalescent`](@ref).
 
 We give examples below of how we may use this mapping information.
 
-## naming internal nodes in the network and gene trees
+## naming internal nodes
 
 First, it's useful to name internal nodes in the network, to which we
 can later map nodes in the gene tree.
@@ -85,19 +85,7 @@ nodes and the extra edges between these nodes.
 But we may want to "clean" gene trees of their degree-2 nodes at some point.
 This can be done with the `PhyloNetworks` utility `removedegree2nodes!`, like this:
 
-```julia
+```@repl mapping
 PhyloNetworks.removedegree2nodes!(tree, true)
 ```
 The option `true` is to keep the root, even if it's of degree 2.
-
-!!! note
-    This option is available in the development version of PhyloNetworks
-    (and will be available in the next registered version).
-    Using PhyloNetworks v0.15.0, which does not have this option, do this instead:
-    ```julia
-    PhyloNetworks.removedegree2nodes!(tree)
-    ```
-    It will remove *all* degree-2 nodes, including the root.
-    This is not a problem for simulating sequences along gene trees when using a
-    reversible substitution model, for which the root placement doesn't matter.
-

--- a/docs/src/man/more_examples.md
+++ b/docs/src/man/more_examples.md
@@ -1,0 +1,123 @@
+```@setup downstreamexamples
+using PhyloNetworks, PhyloCoalSimulations
+net = readTopology("((C:0.9,(B:0.2)#H1:0.7::0.6)I1:0.6,(#H1:0.6::0.4,A:1.0)I2:0.5)I3;");
+using Random; Random.seed!(261); # as in mapping block
+tree = simulatecoalescent(net,1,1; nodemapping=true)[1];
+```
+# example uses
+
+We are re-using the same network and simulated tree as before:
+```@repl downstreamexamples
+writeTopology(net)
+writeTopology(tree, round=true)
+```
+![example 1, same as in mapping section](../assets/figures/genetree_example1.svg)
+
+##  counting deep coalescences
+
+The number of deep coalescences can be quantified as the number of
+"extra" lineages due to incomplete lineage sorting, that can be calculated
+from embedding the gene tree into the species phylogeny
+(see [Maddison 1997](https://doi.org/10.1093/sysbio/46.3.523) for species trees).
+For a speciation node in the species tree (e.g. I1), there are extra lineages
+in the gene tree, owing to a lack of coalescence, if there are more than 2 gene
+lineages mapping to this speciation node.
+For each hybridization node (e.g. H1), there are extra lineages if there are
+more than 1 gene lineage mapping to this hybridization node
+(because there's only 1 child edge descending from a hybridization node).
+
+We can count the number of extra lineages by counting the number of degree-2
+nodes in the gene tree mapping to each node in the species network, then
+counting how many are "extra".
+In our gene tree above, we can do it this way:
+
+```@repl downstreamexamples
+node_count = Dict(n.name => 0      for n in net.node if !n.leaf) # ignore leaves
+node_hyb = Dict(n.name => n.hybrid for n in net.node if !n.leaf) # true/1 for hybrid nodes
+# traverse the gene tree, to count number of lineages entering each network node
+for n in tree.node
+  (n.leaf || n.name == "") && continue # skip leaves and nodes without a name
+  node_count[n.name] += 1  # increment by 1 the number of lineages entering this node
+end
+node_count # the 2 lineages entering I2 didn't coalesce until they reached I3
+for node in keys(node_count) # modify our counts, to only keep the extras
+  node_count[node] = max(0, node_count[node] - ( node_hyb[node] ? 1 : 2))
+end
+node_count # number of extra lineages: 1 extra entering I3
+deepcoalescence = sum(values(node_count))
+```
+On the particular gene tree we simulated, we counted 1 deep coalescence.
+
+## number of lineages inherited via gene flow
+
+Our network has inheritance γ=0.4 on the minor edge, which we'll call the
+"gene flow" edge, and γ=0.6 on the major hybrid edge, parent to H1 on the major tree.
+But we may be interested in the realized proportion of lineages inherited
+from each parent at H1, realized in the gene trees we actually simulated.
+To do so, we can count the number of gene lineages that are mapped to each
+hybrid edge in the network.
+
+This mapping is stored in the edge attribute `.inCycle`.
+From the plot above, the minor "gene flow" edge is edge number 5 and the
+major hybrid edge has number 3.
+So we can count the gene lineages inherited via gene flow
+as the number of gene tree edges with `inCycle` equal to 5.
+
+If the gene trees have been saved to a file and later read from this file,
+then the `.inCycle` attributes are no longer stored in memory. In this case,
+we can retrieve the mapping information by the internal node names.
+The edges going through gene flow are those whose child node is named "H1"
+and parent node is named "I2".
+
+We use the first option with the `.inCycle` attribute below.
+We get that our one simulated gene tree was indeed inherited via gene flow:
+
+```@repl downstreamexamples
+sum(e.inCycle == 5 for e in tree.edge)
+```
+
+To make this more interesting, we can simulate many gene trees
+then count how many of their lineages were inherited via gene flow.
+If we ask for 2 individuals in species B,
+then each gene may have 2 lineages that enter the hybrid node H1,
+if the two B individuals fail to coalesce. In that case, it's possible that one
+individual lineage was inherited via gene flow, and the other not.
+We'll calculate the gene flow proportion among all these lineages.
+This proportion should be close (but not exactly equal) to the theoretical
+γ=0.4 from the network model.
+
+```@repl downstreamexamples
+ngenes = 100
+genetrees = simulatecoalescent(net, ngenes, Dict("B"=>2, "A"=>1, "C"=>1); nodemapping=true);
+length(genetrees)
+nlineages_geneflow = sum(sum(e.inCycle == 5 for e in gt.edge) for gt in genetrees)
+nlineages_major    = sum(sum(e.inCycle == 3 for e in gt.edge) for gt in genetrees)
+# realized γ, close to 0.4:
+proportion_geneflow = nlineages_geneflow / (nlineages_geneflow + nlineages_major)
+```
+
+## rate variation across species
+
+The gene trees resulting from `simulatecoalescent` have their edge lengths
+in coalescent units. One may want to convert them to substitutions per site,
+so as to simulate molecular sequences along these gene trees.
+The mapping information is important to allow for different rates of molecular
+evolution across different species. Here is an example to do this.
+
+We will use the `Distributions` package to simulate rates from a log-normal
+distribution across species, that is, across edges in the species network.
+
+```@repl downstreamexamples
+using Distributions
+lognormal_rate_dist = LogNormal(-0.125, 0.5) # μ = -σ²/2 to get a mean of 1.
+networkedge_rate = Dict(e.number => rand(lognormal_rate_dist) for e in net.edge)
+# add entry for the edge above the network's root. Find its number first.
+rootedgenumber = maximum(e.number for e in net.edge) + 1
+push!(networkedge_rate, rootedgenumber => rand(lognormal_rate_dist))
+writeTopology(tree, round=true, digits=4) # before rate variation
+# multiply the length of each gene lineage by the rate of the species edge it maps into
+for e in tree.edge
+  e.length *= networkedge_rate[e.inCycle]
+end
+writeTopology(tree, round=true, digits=4) # after rate variation
+```

--- a/docs/src/man/more_examples.md
+++ b/docs/src/man/more_examples.md
@@ -112,7 +112,7 @@ using Distributions
 lognormal_rate_dist = LogNormal(-0.125, 0.5) # μ = -σ²/2 to get a mean of 1.
 networkedge_rate = Dict(e.number => rand(lognormal_rate_dist) for e in net.edge)
 # add entry for the edge above the network's root. Find its number first.
-rootedgenumber = maximum(e.number for e in net.edge) + 1
+rootedgenumber = PhyloCoalSimulations.get_rootedgenumber(net)
 push!(networkedge_rate, rootedgenumber => rand(lognormal_rate_dist))
 writeTopology(tree, round=true, digits=4) # before rate variation
 # multiply the length of each gene lineage by the rate of the species edge it maps into

--- a/src/simulatecoalescent_network.jl
+++ b/src/simulatecoalescent_network.jl
@@ -1,9 +1,17 @@
 """
-    simulatecoalescent(net, nloci, nindividuals=1; nodemapping=false)
+    get_rootedgenumber(network)
+
+1 + maximum of 0 and of all the network's edge numbers:
+can be used as a unique identifier of the edge above the network's root.
+"""
+get_rootedgenumber(net) = max(0, maximum(e.number for e in net.edge)) + 1
+
+"""
+    simulatecoalescent(net, nloci, nindividuals; nodemapping=false)
 
 Simulate `nloci` gene trees with `nindividuals` from each species
-under the multispecies network coalescent, along network `net`.
-Branch lengths in `net` are interpreted as being in coalescent units
+under the multispecies network coalescent, along network `net`
+whose branch lengths are assumed to be in **coalescent units**
 (ratio: number of generations / effective population size).
 The coalescent model uses the infinite-population-size approximation.
 
@@ -26,7 +34,7 @@ is carried by the `.name` attribute. Namely:
 - The gene tree's root node (of degree 2) represents a coalescent event
   along the network's root edge.
   Its `.inCycle` attribute is the number assigned to the network's root edge,
-  which is set to the maximum edge number + 1.
+  which is set by [`get_rootedgenumber`](@ref) as the maximum edge number + 1.
 - A leaf (or degree-1 node) represents an individual. It maps to a species
   in `net`. The individual leaf name is set to the species name
   if `nindividuals` is 1. Otherwise, its name is set to `speciesname_i`
@@ -51,7 +59,7 @@ julia> net = readTopology("(A:1,B:1);"); # branch lengths of 1 coalescent unit
 
 julia> using Random; Random.seed!(54321); # for replicability of examples below
 
-julia> simulatecoalescent(net, 2) # 2 gene trees, default of 1 individual/species
+julia> simulatecoalescent(net, 2, 1) # 2 gene trees, 1 individual/species
 2-element Vector{HybridNetwork}:
  PhyloNetworks.HybridNetwork, Rooted Network
 2 edges
@@ -126,7 +134,7 @@ julia> [(tree_edge_number = e.number, pop_edge_number = e.inCycle) for e in tree
  (tree_edge_number = 1, pop_edge_number = 1)
 ```
 """
-function simulatecoalescent(net::PN.HybridNetwork, nloci, nindividuals=1;
+function simulatecoalescent(net::PN.HybridNetwork, nloci::Integer, nindividuals;
         nodemapping=false)
     if isa(nindividuals, AbstractDict)
         issubset(PN.tipLabels(net), keys(nindividuals)) || error("nindividuals is missing some species")
@@ -134,7 +142,7 @@ function simulatecoalescent(net::PN.HybridNetwork, nloci, nindividuals=1;
     elseif isa(nindividuals, Integer)
         nindividuals = Dict(n.name => nindividuals for n in net.leaf)
     else
-        error("nindividuals should be an integer or vector of integers")
+        error("nindividuals should be an integer or dictionary of integers")
     end
     for e in net.edge
         e.hybrid && e.gamma == -1.0 && error("the network needs gamma values")
@@ -155,7 +163,7 @@ function simulatecoalescent(net::PN.HybridNetwork, nloci, nindividuals=1;
         push!(parentedges, parentedgelist)
         push!(childedges, childedgelist)
     end
-    rootedgenumber = max(0, maximum(e.number for e in net.edge)) + 1
+    rootedgenumber = get_rootedgenumber(net)
 
     genetreelist = Vector{PN.HybridNetwork}(undef,nloci)
     for ilocus in 1:nloci
@@ -223,6 +231,94 @@ function simulatecoalescent(net::PN.HybridNetwork, nloci, nindividuals=1;
                 genetreelist[ilocus] = convert2tree!(rootnode)
             end
         end
+    end
+    return genetreelist
+end
+
+"""
+    simulatecoalescent(net, nloci, nindividuals, populationsize;
+        nodemapping=false, round_generationnumber=true)
+
+!!! info
+    Wrapper around the `simulatecoalescent` method that uses edge lengths
+    in coalescent units and that does not take `populationsize` as argument.
+
+Simulate `nloci` gene trees with `nindividuals` from each species
+under the multispecies network coalescent, along network `net`,
+whose branch lengths are assumed to be in **number of generations**.
+`populationsize` should be a single number, assumed to be the
+(haploid) effective population size Nₑ, constant across the species phylogeny.
+Alternatively, `populationsize` can be a dictionary mapping the number of
+each edge in `net` to its Nₑ, including an extra edge number for the
+population above the root of the network.
+
+Coalescent units are then calculated as `u=g/Nₑ` where `g` is the edge length
+in `net` (number of generations), and the coalescent model is applied
+using the infinite-population-size approximation.
+
+Output: vector of gene trees with edge lengths in number of generations,
+calculated as `g=uNₑ` and then rounded to be an integer, unless
+`round_generationnumber` is false.
+
+```jldoctest
+julia> using PhyloNetworks
+
+julia> net = readTopology("(A:500,B:500);"); # branch lengths of 100 generations
+
+julia> Ne = Dict(e.number => 1_000 for e in net.edge);
+
+julia> rootedgenumber = PhyloCoalSimulations.get_rootedgenumber(net)
+
+julia> push!(Ne, rootedgenumber => 2_000) # Ne for population above the root
+Dict{Int64, Int64} with 3 entries:
+  2 => 1000
+  3 => 2000
+  1 => 1000
+
+julia> using Random; Random.seed!(54321); # for replicability of examples below
+
+julia> simulatecoalescent(net, 2, 1, Ne)
+2-element Vector{HybridNetwork}:
+ HybridNetwork, Rooted Network
+2 edges
+3 nodes: 2 tips, 0 hybrid nodes, 1 internal tree nodes.
+tip labels: B, A
+(B:546.0,A:546.0);
+
+ HybridNetwork, Rooted Network
+2 edges
+3 nodes: 2 tips, 0 hybrid nodes, 1 internal tree nodes.
+tip labels: B, A
+(B:3155.0,A:3155.0);
+```
+"""
+function simulatecoalescent(net::PN.HybridNetwork, nloci::Integer, nindividuals, Neff;
+        nodemapping=false, round_generationnumber=true)
+    popedgenumbers = [e.number for e in net.edge]
+    push!(popedgenumbers, get_rootedgenumber(net))
+    if isa(Neff, AbstractDict)
+        issubset(popedgenumbers, keys(Neff)) ||
+            error("populationsize is missing some edge numbers, or the root edge number.")
+        valtype(Neff) <: Number || error("population sizes should be numerical")
+    elseif isa(Neff, Number)
+        Neff = Dict(num => Neff for num in popedgenumbers)
+    else
+        error("populationsize should be a number or dictionary")
+    end
+    # network with lengths in coalescent units
+    net_coal = deepcopy(net)
+    for e in net_coal.edge
+        e.length = e.length / Neff[e.number]
+    end
+    # simulate gene trees
+    genetreelist = simulatecoalescent(net_coal,nloci,nindividuals; nodemapping=true);
+    # convert lengths to #generations in gene trees
+    for gt in genetreelist
+        for e in gt.edge
+            len = e.length * Neff[e.inCycle]
+            e.length = (round_generationnumber ? round(len) : len )
+        end
+        nodemapping || PN.removedegree2nodes!(gt, true) # 'true' option requires PN v0.15.1
     end
     return genetreelist
 end

--- a/src/simulatecoalescent_network.jl
+++ b/src/simulatecoalescent_network.jl
@@ -239,10 +239,6 @@ end
     simulatecoalescent(net, nloci, nindividuals, populationsize;
         nodemapping=false, round_generationnumber=true)
 
-!!! info
-    Wrapper around the `simulatecoalescent` method that uses edge lengths
-    in coalescent units and that does not take `populationsize` as argument.
-
 Simulate `nloci` gene trees with `nindividuals` from each species
 under the multispecies network coalescent, along network `net`,
 whose branch lengths are assumed to be in **number of generations**.
@@ -260,6 +256,13 @@ Output: vector of gene trees with edge lengths in number of generations,
 calculated as `g=uNₑ` and then rounded to be an integer, unless
 `round_generationnumber` is false.
 
+!!! warning
+    When `populationsize` Nₑ is not provided as input, all edge lengths are in
+    coalescent units. When `populationsize` is given as an argument, all edge
+    lengths are in number of generations.
+    The second method (using # generation and Nₑ as input) is a wrapper around
+    the first (using coalescent units).
+
 ```jldoctest
 julia> using PhyloNetworks
 
@@ -268,6 +271,7 @@ julia> net = readTopology("(A:500,B:500);"); # branch lengths of 100 generations
 julia> Ne = Dict(e.number => 1_000 for e in net.edge);
 
 julia> rootedgenumber = PhyloCoalSimulations.get_rootedgenumber(net)
+3
 
 julia> push!(Ne, rootedgenumber => 2_000) # Ne for population above the root
 Dict{Int64, Int64} with 3 entries:
@@ -275,21 +279,14 @@ Dict{Int64, Int64} with 3 entries:
   3 => 2000
   1 => 1000
 
-julia> using Random; Random.seed!(54321); # for replicability of examples below
+julia> using Random; Random.seed!(54321); # for replicability of example below
 
-julia> simulatecoalescent(net, 2, 1, Ne)
-2-element Vector{HybridNetwork}:
- HybridNetwork, Rooted Network
-2 edges
-3 nodes: 2 tips, 0 hybrid nodes, 1 internal tree nodes.
-tip labels: B, A
+julia> genetrees = simulatecoalescent(net, 2, 1, Ne);
+
+julia> writeMultiTopology(genetrees, stdout) # branch lengths: number of generations
 (B:546.0,A:546.0);
-
- HybridNetwork, Rooted Network
-2 edges
-3 nodes: 2 tips, 0 hybrid nodes, 1 internal tree nodes.
-tip labels: B, A
 (B:3155.0,A:3155.0);
+
 ```
 """
 function simulatecoalescent(net::PN.HybridNetwork, nloci::Integer, nindividuals, Neff;

--- a/test/test_multispeciesnetwork.jl
+++ b/test/test_multispeciesnetwork.jl
@@ -62,16 +62,7 @@ gt2 = simulatecoalescent(net, 1, 3; nodemapping=true)[1]
 ndegree2 = checknodeattributes(gt2)
 @test ndegree2 >= 9
 # fuse degree-2 nodes in gt2, then check that gt2 == gt1
-done = false
-while !done
-    done = true
-    for i in reverse(eachindex(gt2.node))
-        n = gt2.node[i]
-        (length(n.edge) == 2 && n !== gt2.node[gt2.root]) || continue
-        done = false
-        PN.fuseedgesat!(i, gt2)
-    end
-end
+PN.removedegree2nodes!(gt2, true)
 @test hardwiredClusterDistance(gt1, gt2, true)==0
 # ideally: also check for equal edge lengths. Not done here
 
@@ -123,4 +114,11 @@ expdist2 = Distributions.Exponential(2)
 @test pvalue(HypothesisTests.OneSampleADTest(d_t2t7 .- d_t2t7_min, expdist2)) >= α
 @test pvalue(HypothesisTests.OneSampleADTest(d_t2t5 .- d_t2t5_min, expdist2)) >= α
 @test pvalue(HypothesisTests.OneSampleADTest(d_t5t7 .- d_t5t7_min, expdist2)) >= α
+
+# on a tree with #generations + Ne dictionary
+net = PN.readTopology("(A:1000,B:1000);")
+Ne = Dict(1=>20, 2=>300, 3=>300)
+Random.seed!(639)
+genetree = PCS.simulatecoalescent(net, 1, 2, Ne)[1]
+@test all(sort!([e.length for e in genetree.edge]) .> [1,1, 15,15, 800,800])
 end

--- a/test/test_multispeciesnetwork.jl
+++ b/test/test_multispeciesnetwork.jl
@@ -77,7 +77,7 @@ Random.seed!(1602)
 genetrees = PCS.simulatecoalescent(net, nsim, 1)
 α = 0.05 # to test "approximately" correct results
 #= expected CF:
-plot(net, :R, showEdgeNumber=true, showGamma=true);
+plot(net, showedgenumber=true, showgamma=true);
 t2,t7 sister after cut edge 6, t8 only descendant of either hybrid node, so:
 expCFminor = exp(-net.edge[4].length) * ((0.6 + 0.4*0.3)*exp(-net.edge[7].length) + 0.4*0.7)/3
 =#


### PR DESCRIPTION
- ultrametricity not required
- edge lengths in coalescent units
- example code to convert coal units to # generations in gene trees